### PR TITLE
feat: update color palette to warm earth tones

### DIFF
--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="20" fill="#f8961e"/>
+  <rect width="100" height="100" rx="20" fill="#D97757"/>
   <text x="50" y="68" font-family="Arial, sans-serif" font-size="50" font-weight="bold" fill="white" text-anchor="middle">F</text>
 </svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,7 +3,7 @@
 }
 
 :root {
-  --bg-primary: #f6f8fa;
+  --bg-primary: #FAF9F7;
   --bg-secondary: #ffffff;
   --text-primary: #1f2937;
   --text-secondary: #57606a;
@@ -16,13 +16,13 @@
   --error-border: #fecaca;
   --error-text: #dc2626;
   --shadow: rgba(0, 0, 0, 0.1);
-  --square-empty: #ebedf0;
+  --square-empty: #E8E6E3;
   --square-outline: rgba(27, 31, 35, 0.06);
 }
 
 [data-theme='dark'] {
-  --bg-primary: #0d1117;
-  --bg-secondary: #161b22;
+  --bg-primary: #1A1A1A;
+  --bg-secondary: #252525;
   --text-primary: #e6edf3;
   --text-secondary: #8b949e;
   --text-tertiary: #c9d1d9;
@@ -34,7 +34,7 @@
   --error-border: #5c2828;
   --error-text: #f87171;
   --shadow: rgba(0, 0, 0, 0.3);
-  --square-empty: #21262d;
+  --square-empty: #2D2D2D;
   --square-outline: rgba(255, 255, 255, 0.1);
 }
 
@@ -85,7 +85,7 @@ body {
   margin: 0;
   font-size: 32px;
   font-weight: 700;
-  color: #f8961e;
+  color: #D97757;
 }
 
 .subtitle {
@@ -137,8 +137,8 @@ body {
 
 .year-selector:focus {
   outline: none;
-  border-color: #f8961e;
-  box-shadow: 0 0 0 3px rgba(248, 150, 30, 0.2);
+  border-color: #D97757;
+  box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.2);
 }
 
 .grid-section {

--- a/frontend/src/components/ActivityModal/ActivityModal.css
+++ b/frontend/src/components/ActivityModal/ActivityModal.css
@@ -107,7 +107,7 @@
   margin: 0;
   width: 16px;
   height: 16px;
-  accent-color: #f8961e;
+  accent-color: #D97757;
 }
 
 .radio-label {
@@ -140,12 +140,12 @@
 }
 
 .btn--primary {
-  background-color: #f8961e;
+  background-color: #D97757;
   color: #ffffff;
 }
 
 .btn--primary:hover:not(:disabled) {
-  background-color: #f3722c;
+  background-color: #C4624A;
 }
 
 .btn--danger {

--- a/frontend/src/components/ActivityOverview/ActivityOverview.css
+++ b/frontend/src/components/ActivityOverview/ActivityOverview.css
@@ -36,15 +36,15 @@
 }
 
 .bar-physical {
-  fill: #f94144;
+  fill: #D97757;
 }
 
 .bar-cardio {
-  fill: #f9c74f;
+  fill: #E8B87D;
 }
 
 .bar-diet {
-  fill: #90be6d;
+  fill: #7D8B7E;
 }
 
 .bar-rest {
@@ -84,15 +84,15 @@
 }
 
 .stat-dot-physical {
-  background-color: #f94144;
+  background-color: #D97757;
 }
 
 .stat-dot-cardio {
-  background-color: #f9c74f;
+  background-color: #E8B87D;
 }
 
 .stat-dot-diet {
-  background-color: #90be6d;
+  background-color: #7D8B7E;
 }
 
 .stat-dot-rest {

--- a/frontend/src/components/ContributionGrid/ContributionGrid.css
+++ b/frontend/src/components/ContributionGrid/ContributionGrid.css
@@ -65,7 +65,7 @@
 }
 
 .day-square:focus {
-  outline: 2px solid #0969da;
+  outline: 2px solid #D97757;
   outline-offset: 1px;
 }
 

--- a/frontend/src/utils/colorUtils.ts
+++ b/frontend/src/utils/colorUtils.ts
@@ -1,12 +1,12 @@
 import type { Activity } from '../types';
 
-// Color palette from colors.txt (warm tones for activity intensity)
+// Color palette (warm earth tones for activity intensity)
 // Empty color uses CSS variable for theme support
 export const COLORS = {
   empty: 'var(--square-empty)',  // CSS variable - automatically updates with theme
-  level1: '#f9c74f',  // Tuscan Sun - lowest activity
-  level2: '#f8961e',  // Carrot Orange
-  level3: '#f94144',  // Strawberry Red - highest activity
+  level1: '#7D8B7E',  // Muted Sage - lowest activity
+  level2: '#E8B87D',  // Soft Amber
+  level3: '#D97757',  // Warm Terracotta - highest activity
 };
 
 export function getActivityScore(activity: Activity | null): number {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Replace activity level colors with warm earth tones: Muted Sage → Soft Amber → Warm Terracotta
- Update theme backgrounds: Soft Cream (#FAF9F7) for light mode, Deep Charcoal (#1A1A1A) for dark mode
- Change accent color to Warm Terracotta (#D97757) throughout UI (title, buttons, focus states)
- Update ActivityOverview chart colors to match new palette
- Add Vite proxy config for API requests during development

## New Color Palette
| Color | Hex | Usage |
|-------|-----|-------|
| Warm Terracotta | #D97757 | Primary accent, highest activity level |
| Soft Amber | #E8B87D | Medium activity level, Cardio chart |
| Muted Sage | #7D8B7E | Lowest activity level, Diet chart |
| Soft Cream | #FAF9F7 | Light theme background |
| Deep Charcoal | #1A1A1A | Dark theme background |

## Test plan
- [ ] Verify light theme uses Soft Cream background
- [ ] Toggle dark mode and verify Deep Charcoal background
- [ ] Check contribution grid shows correct color progression (Sage → Amber → Terracotta)
- [ ] Click on a day to open modal and verify button colors
- [ ] Check ActivityOverview chart bar colors match new palette
- [ ] Verify favicon displays with new Terracotta color

🤖 Generated with [Claude Code](https://claude.com/claude-code)